### PR TITLE
Added space id checking before fetching data

### DIFF
--- a/src/Services/Space/Core/Space.Services.Abstraction/ISpaceService.cs
+++ b/src/Services/Space/Core/Space.Services.Abstraction/ISpaceService.cs
@@ -5,6 +5,7 @@ namespace Space.Services.Abstraction;
 public interface ISpaceService
 {
     Task<IEnumerable<SpaceDto>> GetAllAsync();
+    Task<SpaceDto?> GetByIdAsync(Guid spaceId);
     Task KickMemberAsync(Guid spaceId, string kickedByEmail, string memberEmail);
     Task<IEnumerable<SoulDto>> GetAllMembersAsync(Guid spaceId);
     Task<IEnumerable<TopicDto>> GetAllTopicsAsync(Guid spaceId);

--- a/src/Services/Space/Core/Space.Services/SpaceService.cs
+++ b/src/Services/Space/Core/Space.Services/SpaceService.cs
@@ -27,6 +27,15 @@ public class SpaceService : ISpaceService
         return spaces.Adapt<List<SpaceDto>>();
     }
 
+    public async Task<SpaceDto?> GetByIdAsync(Guid spaceId)
+    {
+        var space = await _repositoryManager.SpaceRepository.GetByIdAsync(spaceId);
+        if (space == null)
+            return null;
+
+        return space.Adapt<SpaceDto>();
+    }
+
     public async Task<IEnumerable<SoulDto>> GetAllMembersAsync(Guid spaceId)
     {
         var space = await _repositoryManager.SpaceRepository.GetByIdAsync(spaceId, true, false);

--- a/src/Services/Space/Infrastructure/Space.Presentation/Controllers/SpaceTopicsController.cs
+++ b/src/Services/Space/Infrastructure/Space.Presentation/Controllers/SpaceTopicsController.cs
@@ -19,8 +19,13 @@ public class SpaceTopicsController : ControllerBase
     [HttpGet]
     [Route("{spaceId}/topics")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<TopicDto>))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetAsync(Guid spaceId)
     {
+        SpaceDto? space = await _serviceManager.SpaceService.GetByIdAsync(spaceId);
+        if (space == null)
+            return NotFound(spaceId);
+
         var result = await _serviceManager.SpaceService.GetAllTopicsAsync(spaceId);
         return Ok(result);
     }

--- a/src/Services/Space/Infrastructure/Space.Presentation/Controllers/SpacesController.cs
+++ b/src/Services/Space/Infrastructure/Space.Presentation/Controllers/SpacesController.cs
@@ -89,8 +89,13 @@ public class SpacesController : ControllerBase
     [HttpGet]
     [Route("{spaceId}/members")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<SoulDto>))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetAllMembersAsync(Guid spaceId)
     {
+        SpaceDto? space = await _serviceManager.SpaceService.GetByIdAsync(spaceId);
+        if (space == null)
+            return NotFound(spaceId);
+
         var result = await _serviceManager.SpaceService.GetAllMembersAsync(spaceId);
         return Ok(result);
     }

--- a/src/Services/Space/Tests/Space.UnitTests/Controllers/SpaceTopicsControllerTests.cs
+++ b/src/Services/Space/Tests/Space.UnitTests/Controllers/SpaceTopicsControllerTests.cs
@@ -25,14 +25,25 @@ public class SpaceTopicsControllerTests
     }
 
     [Fact]
+    public async Task GetAsync_SpaceIdIsInvalid_ReturnsNotFoundResult()
+    {
+        _mockService.Setup(x => x.SpaceService.GetByIdAsync(It.IsAny<Guid>()))
+           .ReturnsAsync((SpaceDto)null!);
+
+        var result = await _controller.GetAsync(It.IsAny<Guid>());
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
     public async Task GetAsync_TopicsAreEmpty_ReturnsOkResultWithEmptyData()
     {
-        Guid spaceId = Guid.NewGuid();
-
-        _mockService.Setup(x => x.SpaceService.GetAllTopicsAsync(spaceId))
+        _mockService.Setup(x => x.SpaceService.GetByIdAsync(It.IsAny<Guid>()))
+           .ReturnsAsync(new SpaceDto());
+        _mockService.Setup(x => x.SpaceService.GetAllTopicsAsync(It.IsAny<Guid>()))
            .ReturnsAsync((IEnumerable<TopicDto>)new List<TopicDto>());
 
-        var result = await _controller.GetAsync(spaceId);
+        var result = await _controller.GetAsync(It.IsAny<Guid>());
 
         var okResult = Assert.IsType<OkObjectResult>(result);
         var spaces = Assert.IsType<List<TopicDto>>(okResult.Value);
@@ -42,9 +53,9 @@ public class SpaceTopicsControllerTests
     [Fact]
     public async Task GetAsync_TopicsAreNotEmpty_ReturnsOkResultWithData()
     {
-        Guid spaceId = Guid.NewGuid();
-
-        _mockService.Setup(x => x.SpaceService.GetAllTopicsAsync(spaceId))
+        _mockService.Setup(x => x.SpaceService.GetByIdAsync(It.IsAny<Guid>()))
+           .ReturnsAsync(new SpaceDto());
+        _mockService.Setup(x => x.SpaceService.GetAllTopicsAsync(It.IsAny<Guid>()))
            .ReturnsAsync((IEnumerable<TopicDto>)new List<TopicDto>
            {
                new TopicDto(),
@@ -52,7 +63,7 @@ public class SpaceTopicsControllerTests
                new TopicDto()
            });
 
-        var result = await _controller.GetAsync(spaceId);
+        var result = await _controller.GetAsync(It.IsAny<Guid>());
 
         var okResult = Assert.IsType<OkObjectResult>(result);
         var topics = Assert.IsType<List<TopicDto>>(okResult.Value);

--- a/src/Services/Space/Tests/Space.UnitTests/Controllers/SpacesControllerTests.cs
+++ b/src/Services/Space/Tests/Space.UnitTests/Controllers/SpacesControllerTests.cs
@@ -248,14 +248,25 @@ public class SpacesControllerTests
     }
 
     [Fact]
+    public async Task GetAllMembersAsync_SpaceIdIsInvalid_ReturnsNotFoundResult()
+    {
+        _mockService.Setup(x => x.SpaceService.GetByIdAsync(It.IsAny<Guid>()))
+           .ReturnsAsync((SpaceDto)null!);
+
+        var result = await _controller.GetAllMembersAsync(It.IsAny<Guid>());
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
     public async Task GetAllMembersAsync_SoulsAreEmpty_ReturnsOkResultWithEmptyData()
     {
-        Guid spaceId = Guid.NewGuid();
-
-        _mockService.Setup(x => x.SpaceService.GetAllMembersAsync(spaceId))
+        _mockService.Setup(x => x.SpaceService.GetByIdAsync(It.IsAny<Guid>()))
+           .ReturnsAsync(new SpaceDto());
+        _mockService.Setup(x => x.SpaceService.GetAllMembersAsync(It.IsAny<Guid>()))
            .ReturnsAsync((IEnumerable<SoulDto>)new List<SoulDto>());
 
-        var result = await _controller.GetAllMembersAsync(spaceId);
+        var result = await _controller.GetAllMembersAsync(It.IsAny<Guid>());
 
         var okResult = Assert.IsType<OkObjectResult>(result);
         var spaces = Assert.IsType<List<SoulDto>>(okResult.Value);
@@ -265,9 +276,9 @@ public class SpacesControllerTests
     [Fact]
     public async Task GetAllMembersAsync_SoulsAreNotEmpty_ReturnsOkResultWithData()
     {
-        Guid spaceId = Guid.NewGuid();
-
-        _mockService.Setup(x => x.SpaceService.GetAllMembersAsync(spaceId))
+        _mockService.Setup(x => x.SpaceService.GetByIdAsync(It.IsAny<Guid>()))
+           .ReturnsAsync(new SpaceDto());
+        _mockService.Setup(x => x.SpaceService.GetAllMembersAsync(It.IsAny<Guid>()))
            .ReturnsAsync((IEnumerable<SoulDto>)new List<SoulDto>
            {
                new SoulDto(),
@@ -275,7 +286,7 @@ public class SpacesControllerTests
                new SoulDto()
            });
 
-        var result = await _controller.GetAllMembersAsync(spaceId);
+        var result = await _controller.GetAllMembersAsync(It.IsAny<Guid>());
 
         var okResult = Assert.IsType<OkObjectResult>(result);
         var souls = Assert.IsType<List<SoulDto>>(okResult.Value);


### PR DESCRIPTION
This will add the NotFound return in the GetMember and GetTopic APIs when the space id is invalid in the Space microservice.